### PR TITLE
Make request_message gray; add a period; remove periods

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ messages:
     request-taken: "&A{mod} is now handling request {request_id}."
     close-error: "&CYou can only close your own requests."
     completed: "{mod} completed your request."
-    completed-message: "{mod} completed your request - {close_message}."
+    completed-message: "{mod} completed your request - {close_message}"
     deleted: "Request {request_id} has been closed by you."
     list:
       header: "&B---- {num_requests} Mod Requests ----"


### PR DESCRIPTION
Makes messages: general: item: request: be consistent with messages: general: list: item:

Add back a period that went missing in switch over to config.yml for messages.

Remove period that got added in switch over to config.yml for messages, and remove other period where moderators would use their own punctuation.
